### PR TITLE
fix: standardize bot name to lowercase in configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "TG-Unban-Bot"
+name = "tg-unban-bot"
 main = "_worker.js"
 compatibility_date = "2026-05-19"
 keep_vars = true


### PR DESCRIPTION
This pull request makes a small change to the project configuration by updating the bot's name in the `wrangler.toml` file to use lowercase letters for consistency.