### PR TITLE
feat: 添加可选的 Observability 日志配置说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,68 @@ id = "你的 KV namespace id"
 
 如果不绑定 KV，自助解封和 GKY 封禁查询仍可运行，但本地黑名单相关命令会提示未绑定 KV。
 
-### 3. 设置环境变量
+### 3. 可选：配置 Observability 日志
+
+Cloudflare Worker 后台可能会提示你在 `wrangler.toml` 中添加 Observability 配置，用来控制 Worker 日志、调用记录和链路追踪。这个配置不是机器人运行的必需项，但强烈建议至少开启 `logs`，因为本项目会通过 `console.log()` 输出 Telegram 更新、权限检查、API 返回等调试信息。
+
+示例配置：
+
+```toml
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1
+```
+
+各参数含义：
+
+| 配置项 | 说明 |
+| --- | --- |
+| `[observability]` | 顶层 Observability 配置。Cloudflare 后台生成的细分配置中，可以在这里保留全局默认值，再分别用 `logs` 和 `traces` 控制具体功能。 |
+| `enabled` | 是否启用对应层级的可观测性功能。`[observability.logs] enabled = true` 表示启用日志；`[observability.traces] enabled = false` 表示关闭链路追踪。 |
+| `head_sampling_rate` | 采样率，范围是 `0` 到 `1`。`1` 表示 100% 请求都采集，`0.1` 表示采集 10%，`0.01` 表示采集 1%。 |
+| `[observability.logs]` | Workers Logs 配置，用于在 Cloudflare 后台查看请求日志、`console.log()`、错误和异常。 |
+| `persist` | 是否把日志或追踪数据保存到 Cloudflare 后台。`true` 方便后续查询；`false` 通常用于只导出到第三方日志平台的场景。 |
+| `invocation_logs` | 是否记录每次 Worker 调用的基础日志，例如请求方式、URL、响应状态、耗时等。关闭后通常还能看到代码中主动输出的日志，但少了每次调用的基础记录。 |
+| `[observability.traces]` | 链路追踪配置，用于分析一次请求内部的调用链和耗时。本项目通常不需要开启，排查复杂性能问题时再打开即可。 |
+
+采样率建议：
+
+- 个人或低流量使用：`head_sampling_rate = 1`，所有请求都记录，排查问题最方便。
+- 中等流量：可以设为 `0.1`，只记录约 10% 请求。
+- 高流量或担心日志额度/费用：可以设为 `0.01` 或更低。
+- 如果正在排查线上问题，可以临时调高到 `1`，处理完再降回去。
+
+如果你只想看机器人日志，推荐保持：
+
+```toml
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+```
+
+修改后需要重新部署：
+
+```bash
+wrangler deploy
+```
+
+### 4. 设置环境变量
 
 ```bash
 wrangler secret put TOKEN
@@ -104,7 +165,7 @@ wrangler secret put GROUP_ID
 
 也可以在 Cloudflare Dashboard 的 Worker 设置页中添加同名变量。
 
-### 4. 部署 Worker
+### 5. 部署 Worker
 
 ```bash
 wrangler deploy
@@ -116,7 +177,7 @@ wrangler deploy
 https://tg-unban-bot.example.workers.dev
 ```
 
-### 5. 初始化 Webhook
+### 6. 初始化 Webhook
 
 访问下面的地址：
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,5 +4,20 @@ compatibility_date = "2026-05-19"
 keep_vars = true
 
 #[[kv_namespaces]]
-#binding = "KV"			                    #KV绑定名默认不可修改
+#binding = "KV"								#KV绑定名默认不可修改
 #id = "40ff47946cdd4ade8856158cec511e3f"	#KV数据库id
+
+[observability]
+enabled = false			# 顶层 Observability 配置。当前配置不通过顶层开关一次性启用，下面单独开启 logs、关闭 traces。
+head_sampling_rate = 1	# 顶层采样率，范围 0~1；1 表示 100% 采样，0.1 表示 10% 采样。
+
+[observability.logs]
+enabled = true			# 启用 Workers Logs，可在 Cloudflare 后台查看 console.log、错误和调用日志。
+head_sampling_rate = 1	# 日志采样率，范围 0~1；低流量可用 1，高流量建议按需改成 0.1 或 0.01。
+persist = true			# 是否把日志保存到 Cloudflare 后台，便于后续查询。
+invocation_logs = true	# 是否记录每次 Worker 调用的基础日志，例如请求、响应状态和耗时。
+
+[observability.traces]
+enabled = false			# 是否启用链路追踪。本项目通常不需要，排查复杂性能问题时再改为 true。
+persist = true			# 若启用 traces，是否把追踪数据保存到 Cloudflare 后台。
+head_sampling_rate = 1	# traces 采样率；enabled = false 时不生效。


### PR DESCRIPTION
This pull request updates the documentation and configuration to add support and detailed guidance for Cloudflare Workers Observability logging. The main focus is to help users enable and configure logs for easier debugging and monitoring, while making it clear that these settings are optional but strongly recommended.

**Documentation improvements:**

* Added a new section to `README.md` explaining how to configure Observability logs in `wrangler.toml`, including sample configuration, parameter explanations, and recommendations for different usage scenarios.
* Updated the setup steps in `README.md` to insert the Observability configuration step before setting environment variables, and incremented subsequent step numbers accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R168) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R180)

**Configuration enhancements:**

* Added an example Observability configuration to `wrangler.toml`, enabling logs by default and providing clear comments for each parameter. This includes enabling logs, disabling traces, and setting sampling rates and persistence options.