### PR TITLE
feat: 修改广告举报信息格式，使用代码块显示被举报ID

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1864,7 +1864,7 @@ function buildAdVoteMessageText(state) {
 	return `⚠️ <b>#广告举报</b>
 ${resultLine}${vetoLine}
 <b>被举报人:</b> ${targetText}
-<b>被举报ID:</b> #${escapeHtml(state.targetUserId)}
+<b>被举报ID:</b> <code>${escapeHtml(state.targetUserId)}</code>
 <b>发起人:</b> ${creatorText}
 
 <b>截止时间:</b> <code>${escapeHtml(deadlineStr)}</code>


### PR DESCRIPTION
This pull request makes a small improvement to the formatting of the ad vote message text. The change wraps the reported user ID in a `<code>` tag for better readability and consistency with other fields.

* Improved formatting of the reported user ID in the ad vote message by wrapping it in a `<code>` tag in the `buildAdVoteMessageText` function in `_worker.js`.